### PR TITLE
npm + connect as server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "mondrian",
+  "version": "0.0.0",
+  "description": "Mondrian is a smart and easy-to-learn vector graphics web app.",
+  "main": "",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "start": "coffee server.coffee",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/artursapek/mondrian.git"
+  },
+  "author": "artursapek",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/artursapek/mondrian/issues"
+  },
+  "homepage": "https://github.com/artursapek/mondrian",
+  "dependencies": {
+    "connect": "~2.12.0"
+  },
+  "devDependencies": {
+    "coffee-script": "~1.6.3",
+    "connect": "~2.12.0",
+    "cake": "~0.1.1",
+    "js-yaml": "~3.0.1"
+  }
+}

--- a/server
+++ b/server
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-python -m SimpleHTTPServer 3000

--- a/server.coffee
+++ b/server.coffee
@@ -1,0 +1,11 @@
+connect = require('connect')
+http = require('http')
+
+directory = __dirname
+
+connect()
+  .use(connect.static(directory))
+  .use(connect.logger('dev'))
+  .listen 3000
+
+console.log 'Listening on port 3000.'


### PR DESCRIPTION
Using `package.json` also us to easily install development dependencies for building.

Also included a `connect` to run the server instead of Python.
