### PR TITLE
Added a deadzone for dragging detection.

### DIFF
--- a/src/ui/cursor-tracking.coffee
+++ b/src/ui/cursor-tracking.coffee
@@ -171,8 +171,8 @@ ui.cursor =
           @currentPosn = new Posn(e)
 
           # Initiate dragging, or continue it if it's been initiated.
-          if @down
-            if not @dragging # First detection of a drag
+          if @down and (@dragging or @currentPosn.distanceFrom(@lastDown) > 3)
+            unless @dragging # First detection of a drag
               ui.startDrag(@lastEvent, @lastDownTarget)
               @dragging = @draggingJustBegan = true
             else


### PR DESCRIPTION
Allows click events to be fired properly when using precision input, such as a wacom tablet.

Feels good enough to me for any tool. Adding per-tool support would be far more complex, as far as I can tell.

Closes #10
