### PR TITLE
Update appcache per-build & untrack.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/assets/javascript/*.js
 build/assets/javascript/*.coffee
 build/*/*.html
 build/assets/style/*.css
+build/app/mondrian.appcache
 
 # Sublime Text #
 ##############

--- a/src/app/mondrian.appcache
+++ b/src/app/mondrian.appcache
@@ -1,5 +1,3 @@
-CACHE MANIFEST
-# Revision 7dd6dff5ec4ce72bcaf38d2739b9f697f8b0ff4f
 /assets/vendor/jquery-2.1.0.min.js
 /assets/vendor/md5.min.js
 /assets/vendor/jquery.tinysort.min.js


### PR DESCRIPTION
Untracking built app cache.
Revision is now a number.
SHA and Date for reference.

May it be said that I despise node's way of doing file read / write operations.

I might end up moving the git SHA stuff into it's own module. Seems useful enough.

Refers to #37 and https://github.com/artursapek/mondrian/issues/13#issuecomment-34120230.
